### PR TITLE
Could not add repo as dependency due to failiing tsc on install

### DIFF
--- a/src/components/Portal.tsx
+++ b/src/components/Portal.tsx
@@ -1,5 +1,6 @@
 import {
     PropsWithChildren,
+    ReactPortal,
     useEffect,
     useLayoutEffect,
     useMemo,
@@ -28,7 +29,7 @@ export default function Portal({
     root: r,
     children,
     className,
-}: PropsWithChildren<PortalProps>) {
+}: PropsWithChildren<PortalProps>): ReactPortal {
     const { current: el } = useRef(document.createElement('div'));
     const root = useMemo(
         () => r ?? document.getElementsByTagName('body')[0],


### PR DESCRIPTION
## Purpose

Fixes not being able to add as dependency (with github as source) for projects using other versions of react. This is apparently an issue with inferred types and different react types versions.
